### PR TITLE
Allows fragments to specify signal filters

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -1440,4 +1440,18 @@ class DashFragment : Fragment() {
         val margin = (dp * d).toInt() // margin in pixels
         return margin
     }
+
+    override fun onResume() {
+        super.onResume()
+        if (!viewModel.isRunning()) {
+            viewModel.startUp(arrayListOf())
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        if (viewModel.isRunning()) {
+            viewModel.shutdown()
+        }
+    }
 }

--- a/android/app/src/main/java/app/candash/cluster/DashRepository.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashRepository.kt
@@ -16,8 +16,8 @@ class DashRepository @ExperimentalCoroutinesApi
         return if (useMockService()) mockPandaService else pandaService
     }
 
-    suspend fun startRequests() {
-        getPandaService().startRequests()
+    suspend fun startRequests(signalNamesToRequest: List<String>) {
+        getPandaService().startRequests(signalNamesToRequest)
     }
 
     fun isRunning() : Boolean {

--- a/android/app/src/main/java/app/candash/cluster/DashViewModel.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashViewModel.kt
@@ -53,13 +53,14 @@ class DashViewModel @Inject constructor(private val dashRepository: DashReposito
         cancelCarStateJob()
         setServerIpAddress(ipAddress)
         setUseMockServer(useMockServer)
-        startUp()
+        startUp(arrayListOf())
         startCarStateJob()
     }
 
-    fun startUp() {
+    // An empty list will return all defined signals
+    fun startUp(signalNamesToRequest: List<String>) {
         viewModelScope.launch {
-            dashRepository.startRequests()
+            dashRepository.startRequests(signalNamesToRequest)
         }
     }
 
@@ -76,6 +77,12 @@ class DashViewModel @Inject constructor(private val dashRepository: DashReposito
     fun carState() : LiveData<CarState> {
         startCarStateJob()
         return carStateData
+    }
+
+    fun clearCarState() {
+        if (carStateData.value != null) {
+            carStateData.value = CarState()
+        }
     }
 
     fun getValue(key: String): Float? {

--- a/android/app/src/main/java/app/candash/cluster/FullscreenActivity.kt
+++ b/android/app/src/main/java/app/candash/cluster/FullscreenActivity.kt
@@ -120,21 +120,6 @@ class FullscreenActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION xor View.SYSTEM_UI_FLAG_FULLSCREEN xor View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY xor View.SYSTEM_UI_FLAG_LAYOUT_STABLE xor View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-        viewModel.startUp()
-    }
-
-    override fun onStart() {
-        super.onStart()
-        viewModel.startUp()
-    }
-
-    override fun onStop() {
-        super.onStop()
-        viewModel.shutdown()
-    }
-    override fun onPause() {
-        super.onPause()
-        // viewModel.shutdown()
     }
 
     override fun onDestroy() {

--- a/android/app/src/main/java/app/candash/cluster/InfoFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/InfoFragment.kt
@@ -56,14 +56,14 @@ class InfoFragment() : Fragment() {
 
         }
         binding.startButton.setOnClickListener {
-            if (viewModel.isRunning() == false){
-                viewModel.startUp()
+            if (!viewModel.isRunning()){
+                viewModel.startUp(signalNames())
             }
 
         }
 
         binding.stopButton.setOnClickListener {
-            if (viewModel.isRunning() == true){
+            if (viewModel.isRunning()){
                 viewModel.shutdown()
             }
         }
@@ -76,6 +76,10 @@ class InfoFragment() : Fragment() {
         }
         binding.scrollView.setOnLongClickListener{
             switchToDash()
+        }
+
+        binding.trash.setOnClickListener {
+            viewModel.clearCarState()
         }
 
         viewModel.carState().observe(viewLifecycleOwner) { carState ->
@@ -96,7 +100,23 @@ class InfoFragment() : Fragment() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (!viewModel.isRunning()) {
+            viewModel.startUp(signalNames())
+        }
+    }
 
+    fun signalNames() : List<String> {
+        return arrayListOf()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        if (viewModel.isRunning()) {
+            viewModel.shutdown()
+        }
+    }
 
     fun switchToDash() : Boolean {
         viewModel.switchToDashFragment()

--- a/android/app/src/main/java/app/candash/cluster/MockPandaService.kt
+++ b/android/app/src/main/java/app/candash/cluster/MockPandaService.kt
@@ -16,7 +16,7 @@ class MockPandaService : PandaService {
     private var shutdown = false
     private var count: AtomicInteger = AtomicInteger(0)
 
-    override suspend fun startRequests() {
+    override suspend fun startRequests(signalNamesToRequest: List<String>) {
         withContext(pandaContext) {
             shutdown = false
             while (!shutdown) {

--- a/android/app/src/main/java/app/candash/cluster/PandaService.kt
+++ b/android/app/src/main/java/app/candash/cluster/PandaService.kt
@@ -3,7 +3,7 @@ package app.candash.cluster
 import kotlinx.coroutines.flow.Flow
 
 interface PandaService {
-    suspend fun startRequests()
+    suspend fun startRequests(signalNamesToRequest: List<String>)
     suspend fun shutdown()
     fun carState() : Flow<CarState>
     fun isRunning() : Boolean

--- a/android/app/src/main/res/drawable/ic_baseline_delete_24.xml
+++ b/android/app/src/main/res/drawable/ic_baseline_delete_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
+</vector>

--- a/android/app/src/main/res/layout/fragment_info.xml
+++ b/android/app/src/main/res/layout/fragment_info.xml
@@ -133,7 +133,7 @@
         android:layout_weight="1"
         >
 
-        <LinearLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
@@ -141,13 +141,29 @@
 
             <TextView
                 android:id="@+id/header_text"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:gravity="center"
                 android:padding="20dp"
                 android:text="@string/panda_data_received"
                 android:textSize="20sp"
-                android:textStyle="bold" />
+                android:textStyle="bold"
+                android:layout_marginStart="50dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/info_text"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/trash"
+                />
+
+            <ImageButton
+                android:id="@+id/trash"
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                app:layout_constraintTop_toTopOf="@id/header_text"
+                app:layout_constraintStart_toEndOf="@id/header_text"
+                app:layout_constraintBottom_toBottomOf="@id/header_text"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:src="@drawable/ic_baseline_delete_24" />
 
             <TextView
                 android:id="@+id/info_text"
@@ -155,9 +171,12 @@
                 android:layout_height="wrap_content"
                 android:padding="20dp"
                 android:textSize="18sp"
-                tools:text="Data goes here" />
+                tools:text="Data goes here"
+                app:layout_constraintTop_toBottomOf="@id/header_text"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
 
-        </LinearLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </ScrollView>
 </LinearLayout>


### PR DESCRIPTION
The purpose of this is to allow the fragments to specify which signals they want/need.  Later, I'd like to use this to make theming easier -- each theme will be able to specify the signals that it wants.

There are quite a few changes to functionality:

* We weren't every clearing filters before, so this diff includes clearing the filters each time we sent the filters.
* We weren't handling the case where we could have more than 48 filters and need to send them in multiple packets.
* We were starting/stopping the PandaService in the Activity.  Now we will be starting/stopping in each fragment (since we expect they may have different filters from each other).
* Starting/stopping in Fragments exposed an issue where we could get stuck in a while loop waiting for shutdown (when we actually hadn't started yet).  I've removed that while-loop -- I don't think it serves a purpose.
* I'm now clearing the car state data after we shutdown.  This is both to make my changes testable, and also to avoid stale data issues.
* I also added a "trash" button to the InfoFragment so that the data in the ScrollView can be cleared.